### PR TITLE
feat: introduce momento cache client wrapper over go-redis client

### DIFF
--- a/MakeFile
+++ b/MakeFile
@@ -1,0 +1,35 @@
+.PHONY: install-devtools
+install-devtools:
+	go install golang.org/x/tools/cmd/goimports@latest
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install github.com/onsi/ginkgo/v2/ginkgo@latest
+
+.PHONY: format
+format:
+	gofmt -s -w .
+
+.PHONY: imports
+imports:
+	goimports -l -w .
+
+.PHONY: tidy
+tidy:
+	go mod tidy
+
+.PHONY: vet
+vet:
+	go vet ./...
+
+.PHONY: lint
+lint: format imports tidy vet
+
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: precommit
+precommit: lint test-momento
+
+.PHONY: test-momento
+test-momento:
+	ginkgo momento-redis/ -- -UseRedis=false

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# momento-go-redis-client
-Momento-backed implementation of the go-redis client
+<img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
+
+[![project status](https://momentohq.github.io/standards-and-practices/badges/project-status-incubating.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
+[![project stability](https://momentohq.github.io/standards-and-practices/badges/project-stability-experimental.svg)](https://github.com/momentohq/standards-and-practices/blob/main/docs/momento-on-github.md)
+
+
+# Momento Go-Redis Compatibility Client
+
+## What and Why?
+
+This project provides a Momento-backed implementation of [go-redis](hhttps://github.com/redis/go-redis)
+The goal is to provide a drop-in replacement for [go-redis](hhttps://github.com/redis/go-redis) so that you can
+use the same code with either a Redis server or with the Momento Cache service!
+
+You can use Momento as your cache engine for any Go project that support a redis-backed cache.
+
+## Usage
+
+- To be added once APIs are implemented. Currently no APIs are supported

--- a/momento-redis/bit_commands.go
+++ b/momento-redis/bit_commands.go
@@ -1,0 +1,57 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) GetBit(ctx context.Context, key string, offset int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SetBit(ctx context.Context, key string, offset int64, value int) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BitCount(ctx context.Context, key string, bitCount *BitCount) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BitOpAnd(ctx context.Context, destKey string, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BitOpOr(ctx context.Context, destKey string, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BitOpXor(ctx context.Context, destKey string, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BitOpNot(ctx context.Context, destKey string, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BitPos(ctx context.Context, key string, bit int64, pos ...int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BitPosSpan(ctx context.Context, key string, bit int8, start, end int64, span string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BitField(ctx context.Context, key string, args ...interface{}) *IntSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/cluster_commands.go
+++ b/momento-redis/cluster_commands.go
@@ -1,0 +1,117 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) ClusterMyShardID(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterSlots(ctx context.Context) *ClusterSlotsCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterShards(ctx context.Context) *ClusterShardsCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterLinks(ctx context.Context) *ClusterLinksCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterNodes(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterMeet(ctx context.Context, host, port string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterForget(ctx context.Context, nodeID string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterReplicate(ctx context.Context, nodeID string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterResetSoft(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterResetHard(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterInfo(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterKeySlot(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterGetKeysInSlot(ctx context.Context, slot int, count int) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterCountFailureReports(ctx context.Context, nodeID string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterCountKeysInSlot(ctx context.Context, slot int) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterDelSlots(ctx context.Context, slots ...int) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterDelSlotsRange(ctx context.Context, min, max int) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterSaveConfig(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterSlaves(ctx context.Context, nodeID string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterFailover(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterAddSlots(ctx context.Context, slots ...int) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClusterAddSlotsRange(ctx context.Context, min, max int) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/expire_commands.go
+++ b/momento-redis/expire_commands.go
@@ -1,0 +1,58 @@
+package momento_redis
+
+import (
+	"context"
+	"time"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) Expire(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ExpireAt(ctx context.Context, key string, tm time.Time) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ExpireTime(ctx context.Context, key string) *DurationCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ExpireNX(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ExpireXX(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ExpireGT(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ExpireLT(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PExpire(ctx context.Context, key string, expiration time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PExpireAt(ctx context.Context, key string, tm time.Time) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PExpireTime(ctx context.Context, key string) *DurationCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/fn_script_commands.go
+++ b/momento-redis/fn_script_commands.go
@@ -1,0 +1,122 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) Eval(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) EvalRO(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ScriptFlush(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ScriptKill(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ScriptLoad(ctx context.Context, script string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionLoad(ctx context.Context, code string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionLoadReplace(ctx context.Context, code string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionDelete(ctx context.Context, libName string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionFlush(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionKill(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionFlushAsync(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionList(ctx context.Context, q FunctionListQuery) *FunctionListCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionDump(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionRestore(ctx context.Context, libDump string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FunctionStats(ctx context.Context) *FunctionStatsCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FCall(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FCallRo(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FCallRO(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Publish(ctx context.Context, channel string, message interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SPublish(ctx context.Context, channel string, message interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/geo_commands.go
+++ b/momento-redis/geo_commands.go
@@ -1,0 +1,62 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) GeoSearch(ctx context.Context, key string, q *GeoSearchQuery) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoSearchLocation(ctx context.Context, key string, q *GeoSearchLocationQuery) *GeoSearchLocationCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoSearchStore(ctx context.Context, key, store string, q *GeoSearchStoreQuery) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoDist(ctx context.Context, key string, member1, member2, unit string) *FloatCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoHash(ctx context.Context, key string, members ...string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoAdd(ctx context.Context, key string, geoLocation ...*GeoLocation) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoPos(ctx context.Context, key string, members ...string) *GeoPosCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoRadius(ctx context.Context, key string, longitude, latitude float64, query *GeoRadiusQuery) *GeoLocationCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoRadiusStore(ctx context.Context, key string, longitude, latitude float64, query *GeoRadiusQuery) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoRadiusByMember(ctx context.Context, key, member string, query *GeoRadiusQuery) *GeoLocationCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GeoRadiusByMemberStore(ctx context.Context, key, member string, query *GeoRadiusQuery) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/hash_commands.go
+++ b/momento-redis/hash_commands.go
@@ -1,0 +1,82 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) HDel(ctx context.Context, key string, fields ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HExists(ctx context.Context, key, field string) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HGet(ctx context.Context, key, field string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HGetAll(ctx context.Context, key string) *MapStringStringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HIncrBy(ctx context.Context, key, field string, incr int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HIncrByFloat(ctx context.Context, key, field string, incr float64) *FloatCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HKeys(ctx context.Context, key string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HLen(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HMGet(ctx context.Context, key string, fields ...string) *SliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HSet(ctx context.Context, key string, values ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HMSet(ctx context.Context, key string, values ...interface{}) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HSetNX(ctx context.Context, key, field string, value interface{}) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HVals(ctx context.Context, key string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HRandField(ctx context.Context, key string, count int) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HRandFieldWithValues(ctx context.Context, key string, count int) *KeyValueSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/list_commands.go
+++ b/momento-redis/list_commands.go
@@ -1,0 +1,148 @@
+package momento_redis
+
+import (
+	"context"
+	"time"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) BLPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BLMPop(ctx context.Context, timeout time.Duration, direction string, count int64, keys ...string) *KeyValuesCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BRPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BRPopLPush(ctx context.Context, source, destination string, timeout time.Duration) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LCS(ctx context.Context, q *LCSQuery) *LCSCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LIndex(ctx context.Context, key string, index int64) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LInsert(ctx context.Context, key, op string, pivot, value interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LInsertBefore(ctx context.Context, key string, pivot, value interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LInsertAfter(ctx context.Context, key string, pivot, value interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LLen(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LMPop(ctx context.Context, direction string, count int64, keys ...string) *KeyValuesCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LPop(ctx context.Context, key string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LPopCount(ctx context.Context, key string, count int) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LPos(ctx context.Context, key string, value string, args LPosArgs) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LPosCount(ctx context.Context, key string, value string, count int64, args LPosArgs) *IntSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LPush(ctx context.Context, key string, values ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LPushX(ctx context.Context, key string, values ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LRange(ctx context.Context, key string, start, stop int64) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LRem(ctx context.Context, key string, count int64, value interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LSet(ctx context.Context, key string, index int64, value interface{}) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LTrim(ctx context.Context, key string, start, stop int64) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) RPop(ctx context.Context, key string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) RPopCount(ctx context.Context, key string, count int) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) RPopLPush(ctx context.Context, source, destination string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) RPush(ctx context.Context, key string, values ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) RPushX(ctx context.Context, key string, values ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LMove(ctx context.Context, source, destination, srcpos, destpos string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BLMove(ctx context.Context, source, destination, srcpos, destpos string, timeout time.Duration) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/misc_commands.go
+++ b/momento-redis/misc_commands.go
@@ -1,0 +1,408 @@
+package momento_redis
+
+import (
+	"context"
+	"time"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) Command(ctx context.Context) *CommandsInfoCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) CommandList(ctx context.Context, filter *FilterBy) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) CommandGetKeys(ctx context.Context, commands ...interface{}) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) CommandGetKeysAndFlags(ctx context.Context, commands ...interface{}) *KeyFlagsCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientGetName(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Echo(ctx context.Context, message interface{}) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Ping(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Quit(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Del(ctx context.Context, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Unlink(ctx context.Context, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Dump(ctx context.Context, key string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Exists(ctx context.Context, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Keys(ctx context.Context, pattern string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Migrate(ctx context.Context, host, port, key string, db int, timeout time.Duration) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Move(ctx context.Context, key string, db int) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ObjectRefCount(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ObjectEncoding(ctx context.Context, key string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ObjectIdleTime(ctx context.Context, key string) *DurationCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Persist(ctx context.Context, key string) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PTTL(ctx context.Context, key string) *DurationCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) RandomKey(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Rename(ctx context.Context, key, newkey string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) RenameNX(ctx context.Context, key, newkey string) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Restore(ctx context.Context, key string, ttl time.Duration, value string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) RestoreReplace(ctx context.Context, key string, ttl time.Duration, value string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Sort(ctx context.Context, key string, sort *Sort) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SortRO(ctx context.Context, key string, sort *Sort) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SortStore(ctx context.Context, key, store string, sort *Sort) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SortInterfaces(ctx context.Context, key string, sort *Sort) *SliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Touch(ctx context.Context, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) TTL(ctx context.Context, key string) *DurationCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Type(ctx context.Context, key string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BZPopMax(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BZPopMin(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BZMPop(ctx context.Context, timeout time.Duration, order string, count int64, keys ...string) *ZSliceWithKeyCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PFAdd(ctx context.Context, key string, els ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PFCount(ctx context.Context, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PFMerge(ctx context.Context, dest string, keys ...string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BgRewriteAOF(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) BgSave(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientKill(ctx context.Context, ipPort string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientKillByFilter(ctx context.Context, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientList(ctx context.Context) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientInfo(ctx context.Context) *ClientInfoCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientPause(ctx context.Context, dur time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientUnpause(ctx context.Context) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientID(ctx context.Context) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientUnblock(ctx context.Context, id int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ClientUnblockWithError(ctx context.Context, id int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ConfigGet(ctx context.Context, parameter string) *MapStringStringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ConfigResetStat(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ConfigSet(ctx context.Context, parameter, value string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ConfigRewrite(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) DBSize(ctx context.Context) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FlushAll(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FlushAllAsync(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FlushDB(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) FlushDBAsync(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Info(ctx context.Context, section ...string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) LastSave(ctx context.Context) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Save(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Shutdown(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ShutdownSave(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ShutdownNoSave(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SlaveOf(ctx context.Context, host, port string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SlowLogGet(ctx context.Context, num int64) *SlowLogCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Time(ctx context.Context) *TimeCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) DebugObject(ctx context.Context, key string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ReadOnly(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ReadWrite(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) MemoryUsage(ctx context.Context, key string, samples ...int) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PubSubChannels(ctx context.Context, pattern string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PubSubNumSub(ctx context.Context, channels ...string) *MapStringIntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PubSubNumPat(ctx context.Context) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PubSubShardChannels(ctx context.Context, pattern string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) PubSubShardNumSub(ctx context.Context, channels ...string) *MapStringIntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ACLLog(ctx context.Context, count int64) *ACLLogCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ACLLogReset(ctx context.Context) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ModuleLoadex(ctx context.Context, conf *ModuleLoadexConfig) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/momento_redis.go
+++ b/momento-redis/momento_redis.go
@@ -1,60 +1,17 @@
 package momento_redis
 
 import (
-	"context"
 	"fmt"
-	"time"
-
-	"github.com/momentohq/client-sdk-go/auth"
-	"github.com/momentohq/client-sdk-go/config"
 	"github.com/momentohq/client-sdk-go/momento"
 )
 
+// MomentoRedisClient wrapper over momento cache client that provides Redis compatible APIs
 type MomentoRedisClient struct {
 	client    momento.CacheClient
 	cacheName string
 }
 
-const AuthTokenEnvVariable string = "MOMENTO_AUTH_TOKEN"
-
-func NewMomentoRedisClientWithDefaultCacheClient(cacheName string) (*MomentoRedisClient, error) {
-	credentials, envErr := auth.NewEnvMomentoTokenProvider(AuthTokenEnvVariable)
-	// fail fast if we can't fetch the credentials from env variable
-	if envErr != nil {
-		return nil, envErr
-	}
-
-	// default client with INFO logging capabilities and a 60-second default TTL for all keys
-	mClient, err := momento.NewCacheClient(config.LaptopLatest(), credentials, 60*time.Second)
-	if err != nil {
-		return nil, err
-	}
-
-	// create cache; it resumes execution normally incase the cache already exists and isn't exceptional
-	_, err = mClient.CreateCache(context.Background(), &momento.CreateCacheRequest{
-		CacheName: cacheName,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	client := MomentoRedisClient{
-		cacheName: cacheName,
-		client:    mClient,
-	}
-
-	return &client, nil
-}
-
 func NewMomentoRedisClient(cacheClient momento.CacheClient, cacheName string) (*MomentoRedisClient, error) {
-	// create cache; it resumes execution normally incase the cache already exists and isn't exceptional
-	_, err := cacheClient.CreateCache(context.Background(), &momento.CreateCacheRequest{
-		CacheName: cacheName,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	client := MomentoRedisClient{
 		cacheName: cacheName,
 		client:    cacheClient,

--- a/momento-redis/momento_redis.go
+++ b/momento-redis/momento_redis.go
@@ -1,0 +1,80 @@
+package momento_redis
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/momento"
+)
+
+type MomentoRedisClient struct {
+	client    momento.CacheClient
+	cacheName string
+}
+
+const AuthTokenEnvVariable string = "MOMENTO_AUTH_TOKEN"
+
+func NewMomentoRedisClientWithDefaultCacheClient(cacheName string) (*MomentoRedisClient, error) {
+	credentials, envErr := auth.NewEnvMomentoTokenProvider(AuthTokenEnvVariable)
+	// fail fast if we can't fetch the credentials from env variable
+	if envErr != nil {
+		return nil, envErr
+	}
+
+	// default client with INFO logging capabilities and a 60-second default TTL for all keys
+	mClient, err := momento.NewCacheClient(config.LaptopLatest(), credentials, 60*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	// create cache; it resumes execution normally incase the cache already exists and isn't exceptional
+	_, err = mClient.CreateCache(context.Background(), &momento.CreateCacheRequest{
+		CacheName: cacheName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	client := MomentoRedisClient{
+		cacheName: cacheName,
+		client:    mClient,
+	}
+
+	return &client, nil
+}
+
+func NewMomentoRedisClient(cacheClient momento.CacheClient, cacheName string) (*MomentoRedisClient, error) {
+	// create cache; it resumes execution normally incase the cache already exists and isn't exceptional
+	_, err := cacheClient.CreateCache(context.Background(), &momento.CreateCacheRequest{
+		CacheName: cacheName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	client := MomentoRedisClient{
+		cacheName: cacheName,
+		client:    cacheClient,
+	}
+	return &client, nil
+}
+
+func (c *MomentoRedisClient) String() string {
+	return fmt.Sprintf("Momento< cache:%s>", c.cacheName)
+}
+
+type UnsupportedOperationError string
+
+func (e UnsupportedOperationError) Error() string { return string(e) }
+
+type RedisError string
+
+func (e RedisError) Error() string { return string(e) }
+
+// RedisError implementing this No-Op method of go-redis interface automatically makes this a Redis
+// error. From Redis v9, only a non-existing key explicitly gives a Redis.Nil error, and
+// all other errors are bubbled up as a RedisError
+func (e RedisError) RedisError() {}

--- a/momento-redis/momento_redis_suite_test.go
+++ b/momento-redis/momento_redis_suite_test.go
@@ -1,0 +1,13 @@
+package momento_redis_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMomentoRedis(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MomentoRedis Suite")
+}

--- a/momento-redis/pipeline_commands.go
+++ b/momento-redis/pipeline_commands.go
@@ -1,0 +1,27 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) Pipeline() Pipeliner {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Pipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmder, error) {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) TxPipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmder, error) {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) TxPipeline() Pipeliner {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/scalar.go
+++ b/momento-redis/scalar.go
@@ -1,0 +1,21 @@
+package momento_redis
+
+import (
+	"context"
+	"time"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) Get(ctx context.Context, key string) *StringCmd {
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *StatusCmd {
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Close() error {
+	// do nothing as this doesn't apply to Momento
+	return nil
+}

--- a/momento-redis/scalar_test.go
+++ b/momento-redis/scalar_test.go
@@ -1,0 +1,26 @@
+package momento_redis_test
+
+import (
+	"fmt"
+
+	. "github.com/momento-redis/go-redis-client/momento-redis/test_helpers"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Unsupported operations", func() {
+	It("errors on get for not supported", func() {
+		fmt.Printf("Value for use redis is %t\n", SContext.UseRedis)
+		defer assertPanic()
+		SContext.Client.Get(SContext.Ctx, "key")
+	})
+	It("errors on set for not supported", func() {
+		defer assertPanic()
+		SContext.Client.Set(SContext.Ctx, "key", "value", 1)
+	})
+})
+
+func assertPanic() {
+	if r := recover(); r == nil {
+		Fail("The code did not panic")
+	}
+}

--- a/momento-redis/scan_commands.go
+++ b/momento-redis/scan_commands.go
@@ -1,0 +1,32 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) Scan(ctx context.Context, cursor uint64, match string, count int64) *ScanCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ScanType(ctx context.Context, cursor uint64, match string, count int64, keyType string) *ScanCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) HScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/set_commands.go
+++ b/momento-redis/set_commands.go
@@ -1,0 +1,102 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) SAdd(ctx context.Context, key string, members ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SCard(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SDiff(ctx context.Context, keys ...string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SInter(ctx context.Context, keys ...string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SInterStore(ctx context.Context, destination string, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SIsMember(ctx context.Context, key string, member interface{}) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SMIsMember(ctx context.Context, key string, members ...interface{}) *BoolSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SMembers(ctx context.Context, key string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SMembersMap(ctx context.Context, key string) *StringStructMapCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SMove(ctx context.Context, source, destination string, member interface{}) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SPop(ctx context.Context, key string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SPopN(ctx context.Context, key string, count int64) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SRandMember(ctx context.Context, key string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SRandMemberN(ctx context.Context, key string, count int64) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SRem(ctx context.Context, key string, members ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SUnion(ctx context.Context, keys ...string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SUnionStore(ctx context.Context, destination string, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/sorted_set_commands.go
+++ b/momento-redis/sorted_set_commands.go
@@ -1,0 +1,252 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) ZAdd(ctx context.Context, key string, members ...Z) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZAddLT(ctx context.Context, key string, members ...Z) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZAddGT(ctx context.Context, key string, members ...Z) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZAddNX(ctx context.Context, key string, members ...Z) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZAddXX(ctx context.Context, key string, members ...Z) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZAddArgs(ctx context.Context, key string, args ZAddArgs) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZAddArgsIncr(ctx context.Context, key string, args ZAddArgs) *FloatCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZCard(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZCount(ctx context.Context, key, min, max string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZLexCount(ctx context.Context, key, min, max string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZIncrBy(ctx context.Context, key string, increment float64, member string) *FloatCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZInter(ctx context.Context, store *ZStore) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZInterWithScores(ctx context.Context, store *ZStore) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZInterStore(ctx context.Context, destination string, store *ZStore) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZMPop(ctx context.Context, order string, count int64, keys ...string) *ZSliceWithKeyCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZMScore(ctx context.Context, key string, members ...string) *FloatSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZPopMax(ctx context.Context, key string, count ...int64) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZPopMin(ctx context.Context, key string, count ...int64) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRange(ctx context.Context, key string, start, stop int64) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRangeWithScores(ctx context.Context, key string, start, stop int64) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRangeByScore(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRangeByLex(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRangeArgs(ctx context.Context, z ZRangeArgs) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRangeArgsWithScores(ctx context.Context, z ZRangeArgs) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRangeStore(ctx context.Context, dst string, z ZRangeArgs) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRank(ctx context.Context, key, member string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRankWithScore(ctx context.Context, key, member string) *RankWithScoreCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRem(ctx context.Context, key string, members ...interface{}) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRemRangeByRank(ctx context.Context, key string, start, stop int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRemRangeByScore(ctx context.Context, key, min, max string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRemRangeByLex(ctx context.Context, key, min, max string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRevRange(ctx context.Context, key string, start, stop int64) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRevRangeWithScores(ctx context.Context, key string, start, stop int64) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRevRangeByScore(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRevRangeByLex(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRevRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRevRank(ctx context.Context, key, member string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRevRankWithScore(ctx context.Context, key, member string) *RankWithScoreCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZScore(ctx context.Context, key, member string) *FloatCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZUnionStore(ctx context.Context, dest string, store *ZStore) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRandMember(ctx context.Context, key string, count int) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZRandMemberWithScores(ctx context.Context, key string, count int) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZUnion(ctx context.Context, store ZStore) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZUnionWithScores(ctx context.Context, store ZStore) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZDiff(ctx context.Context, keys ...string) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZDiffWithScores(ctx context.Context, keys ...string) *ZSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) ZDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/stream_commands.go
+++ b/momento-redis/stream_commands.go
@@ -1,0 +1,162 @@
+package momento_redis
+
+import (
+	"context"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) XAdd(ctx context.Context, a *XAddArgs) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XDel(ctx context.Context, stream string, ids ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XLen(ctx context.Context, stream string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XRange(ctx context.Context, stream, start, stop string) *XMessageSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XRangeN(ctx context.Context, stream, start, stop string, count int64) *XMessageSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XRevRange(ctx context.Context, stream string, start, stop string) *XMessageSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XRevRangeN(ctx context.Context, stream string, start, stop string, count int64) *XMessageSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XRead(ctx context.Context, a *XReadArgs) *XStreamSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XReadStreams(ctx context.Context, streams ...string) *XStreamSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XGroupCreate(ctx context.Context, stream, group, start string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XGroupCreateMkStream(ctx context.Context, stream, group, start string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XGroupSetID(ctx context.Context, stream, group, start string) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XGroupDestroy(ctx context.Context, stream, group string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XGroupCreateConsumer(ctx context.Context, stream, group, consumer string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XGroupDelConsumer(ctx context.Context, stream, group, consumer string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XReadGroup(ctx context.Context, a *XReadGroupArgs) *XStreamSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XAck(ctx context.Context, stream, group string, ids ...string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XPending(ctx context.Context, stream, group string) *XPendingCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XPendingExt(ctx context.Context, a *XPendingExtArgs) *XPendingExtCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XClaim(ctx context.Context, a *XClaimArgs) *XMessageSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XClaimJustID(ctx context.Context, a *XClaimArgs) *StringSliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XAutoClaim(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XAutoClaimJustID(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimJustIDCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XTrimMaxLen(ctx context.Context, key string, maxLen int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XTrimMaxLenApprox(ctx context.Context, key string, maxLen, limit int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XTrimMinID(ctx context.Context, key string, minID string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XTrimMinIDApprox(ctx context.Context, key string, minID string, limit int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XInfoGroups(ctx context.Context, key string) *XInfoGroupsCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XInfoStream(ctx context.Context, key string) *XInfoStreamCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XInfoStreamFull(ctx context.Context, key string, count int) *XInfoStreamFullCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) XInfoConsumers(ctx context.Context, key string, group string) *XInfoConsumersCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/string_commands.go
+++ b/momento-redis/string_commands.go
@@ -1,0 +1,108 @@
+package momento_redis
+
+import (
+	"context"
+	"time"
+
+	. "github.com/redis/go-redis/v9"
+)
+
+func (m *MomentoRedisClient) Append(ctx context.Context, key, value string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Decr(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) DecrBy(ctx context.Context, key string, decrement int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GetRange(ctx context.Context, key string, start, end int64) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GetSet(ctx context.Context, key string, value interface{}) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GetEx(ctx context.Context, key string, expiration time.Duration) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) GetDel(ctx context.Context, key string) *StringCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Incr(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) IncrBy(ctx context.Context, key string, value int64) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) IncrByFloat(ctx context.Context, key string, value float64) *FloatCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) MGet(ctx context.Context, keys ...string) *SliceCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) MSet(ctx context.Context, values ...interface{}) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) MSetNX(ctx context.Context, values ...interface{}) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SetArgs(ctx context.Context, key string, value interface{}, a SetArgs) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SetEx(ctx context.Context, key string, value interface{}, expiration time.Duration) *StatusCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SetXX(ctx context.Context, key string, value interface{}, expiration time.Duration) *BoolCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) SetRange(ctx context.Context, key string, offset int64, value string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) StrLen(ctx context.Context, key string) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) Copy(ctx context.Context, sourceKey string, destKey string, db int, replace bool) *IntCmd {
+
+	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}

--- a/momento-redis/test_helpers/shared_context.go
+++ b/momento-redis/test_helpers/shared_context.go
@@ -1,0 +1,57 @@
+package helpers
+
+import (
+	"context"
+	"flag"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+
+	momentoredis "github.com/momento-redis/go-redis-client/momento-redis"
+	"github.com/redis/go-redis/v9"
+)
+
+type SharedContext struct {
+	// If set to true using command line argument, the same set of tests will be run against Redis on port 6379
+	UseRedis bool
+
+	// Client the wrapper Client implements all methods of the Cmdable interface supporting all Redis commands.
+	// Note that this doesn't include commands exposed by ClusterClient, which isn't applicable if you're
+	// using Momento as we provide resource-level isolation and have no notion of a cluster exposed to our customers.
+	// This type declaration here serves as a validation and compile-time errors will occur if we do not implement
+	// any particular AP exposed the go-redis Client
+	Client redis.Cmdable
+
+	Ctx context.Context
+}
+
+// required so that some Flags are autopopulated by testing without which Ginkgo complains
+var _ = func() bool {
+	testing.Init()
+	return true
+}()
+
+var SContext = NewSharedContext()
+
+func NewSharedContext() SharedContext {
+	shared := SharedContext{}
+	setupFlags(&shared)
+	shared.Ctx = context.Background()
+	return shared
+}
+
+func setupFlags(shared *SharedContext) {
+	flag.BoolVar(&shared.UseRedis, "UseRedis", false, "Whether we want to run the tests using Momento or Redis")
+	flag.Parse()
+}
+
+var _ = BeforeSuite(func() {
+	switch SContext.UseRedis {
+	case true:
+		SContext.Client = redis.NewClient(&redis.Options{
+			Addr: "127.0.0.1:6379",
+		})
+	case false:
+		SContext.Client, _ = momentoredis.NewMomentoRedisClientWithDefaultCacheClient("default_cache")
+	}
+})


### PR DESCRIPTION
In this PR, we introduce a ```MomentoCacheClient``` that is a wrapper over go-redis's client. It implements all the methods of the redis Cmdable [interface](https://github.com/redis/go-redis/blob/master/commands.go#L158) and conforms to the type. In this PR (please look at my 4 self-comments on this PR which are the files that really matter for review and have logic):

- Every API throws an ```UnsupportedOpertaionError``` and the next PRs will start implementing them. Have created multiple files for set, list, etc. 
- To save time, the really functional files in this PR are ```momento_redis.go``` that has the ```MomentoRedisClient``` and helper methods to return new instances of it (note: there's no method overloading in go-lang)
   - The file ```shared_context.go``` contains logic to pass a command line argument to toggle between Momento and Redis.
   - The file ```shared_context.go``` also contains initialization of the client based on the command line argument, and uses the same interface type to initialize both Momento and Redis client.
   - A no-op ```scalar_test.go``` that just makes sure the clients are being initialized and we are throwing ```UnsupportedOperationError``` incase of Momento. 
- MakeFile
