### PR TITLE
feat: add sorted set implementations for popular operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,28 @@ To run against Redis, the command will look like:
 
 ## Current Redis API Support
 
-This library supports the most popular Redis APIs, but does not yet support all Redis APIs. We currently support the most
-common APIs related to string values (GET, SET, etc.). We will be adding support for additional
+This library supports the most popular Redis APIs, but does not yet support all Redis APIs.
+
+<table>
+<tr>
+<td>
+Scalar Operations
+</td>
+<td>
+SET, GET, DEL, SETNX, EXPIRE, TTL
+</td>
+</tr>
+<tr>
+<td>
+Sorted Set Operations
+</td>
+<td>
+ZADD, ZRANGEBYSCORE, ZRANGEBYSCOREWITHSCORES, ZREVRANGEBYSCORE, ZREVRANGEBYSCOREWITHSCORES
+</td>
+</tr>
+</table>
+
+We will be adding support for additional
 APIs in the future. If there is a particular API that you need support for, please drop by our [Discord](https://discord.com/invite/3HkAKjUZGq)
 or e-mail us at [support@momentohq.com](mailto:support@momentohq.com) and let us know!
 

--- a/momento-redis/momento_redis.go
+++ b/momento-redis/momento_redis.go
@@ -50,4 +50,11 @@ type MomentoRedisCmdable interface {
 	Expire(ctx context.Context, key string, expiration time.Duration) *redis.BoolCmd
 	Del(ctx context.Context, keys ...string) *redis.IntCmd
 	TTL(ctx context.Context, key string) *redis.DurationCmd
+
+	// sorted set commands
+	ZAdd(ctx context.Context, key string, members ...redis.Z) *redis.IntCmd
+	ZRangeByScore(ctx context.Context, key string, opt *redis.ZRangeBy) *redis.StringSliceCmd
+	ZRangeByScoreWithScores(ctx context.Context, key string, opt *redis.ZRangeBy) *redis.ZSliceCmd
+	ZRevRangeByScore(ctx context.Context, key string, opt *redis.ZRangeBy) *redis.StringSliceCmd
+	ZRevRangeByScoreWithScores(ctx context.Context, key string, opt *redis.ZRangeBy) *redis.ZSliceCmd
 }

--- a/momento-redis/scalar_test.go
+++ b/momento-redis/scalar_test.go
@@ -373,7 +373,7 @@ func assertUnsupportedOperationPanic(message string) {
 		if ok {
 			Expect(errMsg.Error()).To(ContainSubstring(message))
 		} else {
-			Fail("Unknown panic occured")
+			Fail("Unknown panic occured " + errMsg.Error())
 		}
 	}
 }

--- a/momento-redis/scalar_test.go
+++ b/momento-redis/scalar_test.go
@@ -371,7 +371,7 @@ func assertUnsupportedOperationPanic(message string) {
 	} else {
 		errMsg, ok := r.(momentoredis.UnsupportedOperationError)
 		if ok {
-			Expect(errMsg.Error()).To(Equal(message))
+			Expect(errMsg.Error()).To(ContainSubstring(message))
 		} else {
 			Fail("Unknown panic occured")
 		}

--- a/momento-redis/sorted_set_commands.go
+++ b/momento-redis/sorted_set_commands.go
@@ -2,13 +2,55 @@ package momento_redis
 
 import (
 	"context"
+	"math"
+	"strconv"
+	"strings"
 
+	"github.com/momentohq/client-sdk-go/momento"
+	"github.com/momentohq/client-sdk-go/responses"
 	. "github.com/redis/go-redis/v9"
 )
 
 func (m *MomentoRedisClient) ZAdd(ctx context.Context, key string, members ...Z) *IntCmd {
 
-	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+	elements := make([]momento.SortedSetElement, 0, len(members))
+	marshaller := &Marshaller{}
+	for i := 0; i < len(members); i++ {
+		member := members[i]
+		// the member itself could be a string, int or other types
+		val, err := marshaller.MarshalRedisValue(member.Member)
+		if err != nil {
+			panic(UnsupportedOperationError("Member type not supported " + err.Error()))
+		}
+		momentoElement := &momento.SortedSetElement{
+			Score: member.Score,
+			Value: momento.String(val),
+		}
+		elements = append(elements, *momentoElement)
+	}
+
+	resp := &IntCmd{}
+
+	sortedSetPutResponse, err := m.client.SortedSetPutElements(ctx, &momento.SortedSetPutElementsRequest{
+		CacheName: m.cacheName,
+		SetName:   key,
+		Elements:  elements,
+	})
+
+	if err != nil {
+		resp.SetErr(RedisError(err.Error()))
+		return resp
+	}
+
+	switch sortedSetPutResponse.(type) {
+	case *responses.SortedSetPutElementsSuccess:
+		// redis returns the number of sorted set elements that were successfully stored
+		resp.SetVal(int64(len(elements)))
+	case error:
+		resp.SetErr(RedisError(err.Error()))
+	}
+
+	return resp
 }
 
 func (m *MomentoRedisClient) ZAddLT(ctx context.Context, key string, members ...Z) *IntCmd {
@@ -112,8 +154,7 @@ func (m *MomentoRedisClient) ZRangeWithScores(ctx context.Context, key string, s
 }
 
 func (m *MomentoRedisClient) ZRangeByScore(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd {
-
-	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+	return m.zRangeByScoreWithOrder(ctx, key, opt, momento.ASCENDING)
 }
 
 func (m *MomentoRedisClient) ZRangeByLex(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd {
@@ -122,8 +163,7 @@ func (m *MomentoRedisClient) ZRangeByLex(ctx context.Context, key string, opt *Z
 }
 
 func (m *MomentoRedisClient) ZRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd {
-
-	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+	return m.zRangeByScoreWithScoresWithOrder(ctx, key, opt, momento.ASCENDING)
 }
 
 func (m *MomentoRedisClient) ZRangeArgs(ctx context.Context, z ZRangeArgs) *StringSliceCmd {
@@ -182,8 +222,7 @@ func (m *MomentoRedisClient) ZRevRangeWithScores(ctx context.Context, key string
 }
 
 func (m *MomentoRedisClient) ZRevRangeByScore(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd {
-
-	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+	return m.zRangeByScoreWithOrder(ctx, key, opt, momento.DESCENDING)
 }
 
 func (m *MomentoRedisClient) ZRevRangeByLex(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd {
@@ -192,8 +231,7 @@ func (m *MomentoRedisClient) ZRevRangeByLex(ctx context.Context, key string, opt
 }
 
 func (m *MomentoRedisClient) ZRevRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd {
-
-	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+	return m.zRangeByScoreWithScoresWithOrder(ctx, key, opt, momento.DESCENDING)
 }
 
 func (m *MomentoRedisClient) ZRevRank(ctx context.Context, key, member string) *IntCmd {
@@ -249,4 +287,162 @@ func (m *MomentoRedisClient) ZDiffWithScores(ctx context.Context, keys ...string
 func (m *MomentoRedisClient) ZDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd {
 
 	panic(UnsupportedOperationError("This operation has not been implemented yet"))
+}
+
+func (m *MomentoRedisClient) zRangeByScoreWithOrder(ctx context.Context, key string, opt *ZRangeBy, dir momento.SortedSetOrder) *StringSliceCmd {
+	resp := &StringSliceCmd{}
+
+	mZrange := validateFetchByScoreOptions(opt)
+
+	sortedSetFetchByScoreRequest := &momento.SortedSetFetchByScoreRequest{
+		CacheName: m.cacheName,
+		SetName:   key,
+		Count:     mZrange.Count,
+		Offset:    mZrange.Offset,
+		MinScore:  mZrange.MinScore,
+		MaxScore:  mZrange.MaxScore,
+		Order:     dir,
+	}
+
+	sSetFetch, err := m.client.SortedSetFetchByScore(ctx, sortedSetFetchByScoreRequest)
+
+	if err != nil {
+		resp.SetErr(err)
+		return resp
+	}
+
+	switch r := sSetFetch.(type) {
+	case *responses.SortedSetFetchHit:
+		elements := r.ValueStringElements()
+		var val = make([]string, 0, len(elements))
+		for i := 0; i < len(elements); i++ {
+			val = append(val, elements[i].Value)
+		}
+		resp.SetVal(val)
+	case *responses.SortedSetFetchMiss:
+		// empty array is default
+	}
+	return resp
+}
+
+func (m *MomentoRedisClient) zRangeByScoreWithScoresWithOrder(ctx context.Context, key string, opt *ZRangeBy, dir momento.SortedSetOrder) *ZSliceCmd {
+	resp := &ZSliceCmd{}
+
+	mZrange := validateFetchByScoreOptions(opt)
+
+	sortedSetFetchByScoreRequest := &momento.SortedSetFetchByScoreRequest{
+		CacheName: m.cacheName,
+		SetName:   key,
+		Count:     mZrange.Count,
+		Offset:    mZrange.Offset,
+		MinScore:  mZrange.MinScore,
+		MaxScore:  mZrange.MaxScore,
+		Order:     dir,
+	}
+
+	sSetFetch, err := m.client.SortedSetFetchByScore(ctx, sortedSetFetchByScoreRequest)
+
+	if err != nil {
+		resp.SetErr(err)
+		return resp
+	}
+
+	switch r := sSetFetch.(type) {
+	case *responses.SortedSetFetchHit:
+		elements := r.ValueStringElements()
+		var val = make([]Z, 0, len(elements))
+		for i := 0; i < len(elements); i++ {
+			redisElement := Z{
+				Score:  elements[i].Score,
+				Member: elements[i].Value,
+			}
+			val = append(val, redisElement)
+		}
+		resp.SetVal(val)
+	case *responses.SortedSetFetchMiss:
+		// empty array is default
+	}
+
+	return resp
+}
+
+type MomentoZRangeBy struct {
+	MinScore *float64
+	MaxScore *float64
+	Offset   *uint32
+	Count    *uint32
+}
+
+func validateFetchByScoreOptions(opt *ZRangeBy) MomentoZRangeBy {
+	mZRange := &MomentoZRangeBy{}
+	if opt.Count < 0 {
+		panic(UnsupportedOperationError("Negative count is not supported by Momento"))
+	}
+	if opt.Count > math.MaxUint32 {
+		panic(UnsupportedOperationError("Count exceeds max supported integer value by Momento"))
+	}
+	if opt.Offset < 0 {
+		panic(UnsupportedOperationError("Negative offset is not supported by Momento"))
+	}
+	if opt.Offset > math.MaxUint32 {
+		panic(UnsupportedOperationError("Offset exceeds max supported integer value by Momento"))
+	}
+
+	// this is yet another special case. Go-Redis doesn't specify Count as a pointer, so we cannot reference
+	// it for a null check. Go-lang by default treats integers as 0. So a Redis customer can not provide the
+	// count and still have all the elements in the sorted-set even if Go-Lang treats it as 0. This is because
+	// Redis simply streams the entire command as a string for the params provided by the client and excludes
+	// the default 0 count. In case of Momento, we don't want to send this default value as it will always
+	// result in returning an empty set of values.
+	if opt.Count != 0 {
+		count := uint32(opt.Count)
+		mZRange.Count = &count
+	}
+
+	offset := uint32(opt.Offset)
+	mZRange.Offset = &offset
+
+	// if client provided +inf, we don't pass anything to Momento as that's the default UnboundedMax
+	// the length check is present because an empty string is treated as 0 and will be assigned as such later
+	if opt.Min != "-inf" && len(opt.Min) > 0 {
+		if strings.HasPrefix(opt.Min, "(") {
+			panic("Momento currently does not support exclusion of scores. Please omit ( from your" +
+				" request and retry. Reach out to us at Discord https://discord.com/invite/3HkAKjUZGq) or e-mail us at " +
+				"support@momentohq.com if you want such capabilities!")
+		}
+		val, err := strconv.ParseFloat(opt.Min, 64)
+		if err != nil {
+			panic("Cannot parse string MinScore into float, MinScore: " + opt.Min)
+		}
+		mZRange.MinScore = &val
+	}
+
+	// if client provided +inf, we don't pass anything to Momento as that's the default UnboundedMax
+	// the length check is present because an empty string is treated as 0 and will be assigned as such later
+	if opt.Max != "+inf" && len(opt.Max) > 0 {
+		if strings.HasPrefix(opt.Max, "(") {
+			panic("Momento currently does not support exclusion of scores. Please omit ( from your" +
+				" request and retry. Reach out to us at Discord https://discord.com/invite/3HkAKjUZGq) or e-mail us at " +
+				"support@momentohq.com if you want such capabilities!")
+		}
+		val, err := strconv.ParseFloat(opt.Max, 64)
+		if err != nil {
+			panic("Cannot parse string MaxScore into float")
+		}
+		mZRange.MaxScore = &val
+	}
+
+	// Redis considers empty string to be 0
+	if len(opt.Min) == 0 {
+		score := float64(0)
+		mZRange.MinScore = &score
+	}
+
+	// Redis considers empty string to be 0
+	if len(opt.Max) == 0 {
+		score := float64(0)
+		mZRange.MaxScore = &score
+	}
+
+	return *mZRange
 }

--- a/momento-redis/sorted_set_commands.go
+++ b/momento-redis/sorted_set_commands.go
@@ -427,7 +427,7 @@ func validateFetchByScoreOptions(opt *ZRangeBy) MomentoZRangeBy {
 		}
 		val, err := strconv.ParseFloat(opt.Max, 64)
 		if err != nil {
-			panic("Cannot parse string MaxScore into float")
+			panic("Cannot parse string MaxScore into float, MaxScore: " + opt.Max)
 		}
 		mZRange.MaxScore = &val
 	}

--- a/momento-redis/sorted_set_commands.go
+++ b/momento-redis/sorted_set_commands.go
@@ -406,9 +406,9 @@ func validateFetchByScoreOptions(opt *ZRangeBy) MomentoZRangeBy {
 	// the length check is present because an empty string is treated as 0 and will be assigned as such later
 	if opt.Min != "-inf" && len(opt.Min) > 0 {
 		if strings.HasPrefix(opt.Min, "(") {
-			panic("Momento currently does not support exclusion of scores. Please omit ( from your" +
+			panic(UnsupportedOperationError("Momento currently does not support exclusion of scores. Please omit ( from your" +
 				" request and retry. Reach out to us at Discord https://discord.com/invite/3HkAKjUZGq) or e-mail us at " +
-				"support@momentohq.com if you want such capabilities!")
+				"support@momentohq.com if you want such capabilities!"))
 		}
 		val, err := strconv.ParseFloat(opt.Min, 64)
 		if err != nil {
@@ -421,9 +421,9 @@ func validateFetchByScoreOptions(opt *ZRangeBy) MomentoZRangeBy {
 	// the length check is present because an empty string is treated as 0 and will be assigned as such later
 	if opt.Max != "+inf" && len(opt.Max) > 0 {
 		if strings.HasPrefix(opt.Max, "(") {
-			panic("Momento currently does not support exclusion of scores. Please omit ( from your" +
+			panic(UnsupportedOperationError("Momento currently does not support exclusion of scores. Please omit ( from your" +
 				" request and retry. Reach out to us at Discord https://discord.com/invite/3HkAKjUZGq) or e-mail us at " +
-				"support@momentohq.com if you want such capabilities!")
+				"support@momentohq.com if you want such capabilities!"))
 		}
 		val, err := strconv.ParseFloat(opt.Max, 64)
 		if err != nil {

--- a/momento-redis/sorted_set_commands_test.go
+++ b/momento-redis/sorted_set_commands_test.go
@@ -1,0 +1,304 @@
+package momento_redis_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/momentohq/client-sdk-go/auth"
+	"github.com/momentohq/client-sdk-go/config"
+	"github.com/momentohq/client-sdk-go/momento"
+	momentoredis "github.com/momentohq/momento-go-redis-client/momento-redis"
+
+	. "github.com/momentohq/momento-go-redis-client/momento-redis/test_helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+)
+
+var _ = Describe("Sorted Set methods", func() {
+	sContext := NewSharedContext()
+	BeforeEach(func() {
+		cacheName := "default_cache"
+		switch sContext.UseRedis {
+		case true:
+			host := "127.0.0.1"
+			port := "6379"
+			sContext.Client = redis.NewClient(&redis.Options{
+				Addr: host + ":" + port,
+			})
+		case false:
+			credential, _ := auth.NewEnvMomentoTokenProvider(AuthTokenEnvVariable)
+			mClient, _ := momento.NewCacheClient(config.LaptopLatest(), credential, 60*time.Second)
+			sContext.MomentoClient = mClient
+			// create cache; it resumes execution normally incase the cache already exists and isn't exceptional
+			_, createErr := sContext.CreateCache(sContext.Ctx, mClient, cacheName)
+			if createErr != nil {
+				panic("Failed to create cache with cache name " + cacheName + "\n" + createErr.Error())
+			}
+
+			sContext.Client = momentoredis.NewMomentoRedisClient(mClient, cacheName)
+		}
+		DeferCleanup(func() {
+			if sContext.UseRedis {
+				sContext.Client.FlushDB(sContext.Ctx)
+			} else {
+				_, deleteErr := sContext.DeleteCache(sContext.Ctx, sContext.MomentoClient, cacheName)
+				if deleteErr != nil {
+					panic("Failed to delete cache with cache name " + cacheName + "\n" + deleteErr.Error())
+				}
+			}
+		})
+	})
+
+	var _ = Describe("Sorted set add", func() {
+		It("Adds to sorted set", func() {
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sset", *member1, *member2)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(2)))
+		})
+
+		It("Adds to sorted set unsupported type and panics", func() {
+			if sContext.UseRedis {
+				return
+			}
+			type random struct{}
+			member1 := &redis.Z{
+				Member: "member1",
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: &random{},
+				Score:  100,
+			}
+			defer assertUnsupportedOperationPanic("Member type not supported")
+			sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2)
+
+		})
+	})
+
+	var _ = Describe("Sorted set fetch by score", func() {
+		It("Fetch by score happy case", func() {
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(2)))
+			zRange := &redis.ZRangeBy{
+				Min:   "0",
+				Max:   "100",
+				Count: int64(2),
+			}
+			zResp := sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(2))
+			Expect(zResp.Val()[0]).To(Equal(member1.Member))
+			Expect(zResp.Val()[1]).To(Equal(member2.Member))
+
+			// try with offset
+			zRange = &redis.ZRangeBy{
+				Min:    "0",
+				Max:    "100",
+				Count:  int64(2),
+				Offset: int64(1),
+			}
+			zResp = sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+			Expect(len(zResp.Val())).To(Equal(1))
+			Expect(zResp.Val()[0]).To(Equal(member2.Member))
+		})
+
+		It("Fetch by score no Min", func() {
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			member3 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  -5,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2, *member3)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(3)))
+			// Min will considered 0 since it's empty string and member3 won't be included
+			zRange := &redis.ZRangeBy{
+				Min: "",
+				Max: "100",
+			}
+			zResp := sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(2))
+			Expect(zResp.Val()[0]).To(Equal(member1.Member))
+			Expect(zResp.Val()[1]).To(Equal(member2.Member))
+
+			// let's also test without a Min altogether
+			// // Min will considered 0 since it's not present and member3 won't be included
+			zRange = &redis.ZRangeBy{
+				Max: "99",
+			}
+			zResp = sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(1))
+			Expect(zResp.Val()[0]).To(Equal(member1.Member))
+		})
+
+		It("Fetch by score no Max", func() {
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			member3 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  -6,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2, *member3)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(3)))
+
+			zRange := &redis.ZRangeBy{
+				Min: "5",
+			}
+			// since no Max is provided, it will be considered 0 as it's an empty string
+			zResp := sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(0))
+
+			// let's also test without a Max altogether.
+			// since no Max is provided, it will be considered 0 as it's an empty string; therefore,
+			// the member will score -6 will now be included
+			zRange = &redis.ZRangeBy{
+				Min: "-10",
+			}
+			zResp = sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(1))
+			Expect(zResp.Val()[0]).To(Equal(member3.Member))
+		})
+
+		It("Fetch by score no min and no max empty result", func() {
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(2)))
+			zRange := &redis.ZRangeBy{}
+			zResp := sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(0))
+		})
+
+		It("Fetch by score reverse order", func() {
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(2)))
+			zRange := &redis.ZRangeBy{
+				Min: "0",
+				Max: "100",
+			}
+			zResp := sContext.Client.ZRevRangeByScore(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(2))
+			// first element in result is member 2 with score 100
+			Expect(zResp.Val()[0]).To(Equal(member2.Member))
+			Expect(zResp.Val()[1]).To(Equal(member1.Member))
+		})
+
+		It("Fetch by score with score", func() {
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(2)))
+			zRange := &redis.ZRangeBy{
+				Min:   "0",
+				Max:   "100",
+				Count: int64(2),
+			}
+			zResp := sContext.Client.ZRangeByScoreWithScores(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(2))
+			Expect(zResp.Val()[0].Member).To(Equal(member1.Member))
+			Expect(zResp.Val()[0].Score).To(Equal(member1.Score))
+			Expect(zResp.Val()[1].Member).To(Equal(member2.Member))
+			Expect(zResp.Val()[1].Score).To(Equal(member2.Score))
+		})
+
+		It("Fetch by score with score reverse order", func() {
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98.2,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(2)))
+			zRange := &redis.ZRangeBy{
+				Min:   "0",
+				Max:   "100",
+				Count: int64(2),
+			}
+			zResp := sContext.Client.ZRevRangeByScoreWithScores(sContext.Ctx, "sortedSet", zRange)
+
+			Expect(zResp.Err()).To(BeNil())
+			Expect(len(zResp.Val())).To(Equal(2))
+			Expect(zResp.Val()[1].Member).To(Equal(member1.Member))
+			Expect(zResp.Val()[1].Score).To(Equal(member1.Score))
+			Expect(zResp.Val()[0].Member).To(Equal(member2.Member))
+			Expect(zResp.Val()[0].Score).To(Equal(member2.Score))
+		})
+	})
+
+})

--- a/momento-redis/sorted_set_commands_test.go
+++ b/momento-redis/sorted_set_commands_test.go
@@ -123,6 +123,57 @@ var _ = Describe("Sorted Set methods", func() {
 			Expect(zResp.Val()[0]).To(Equal(member2.Member))
 		})
 
+		It("Fetch by score with exclusion rule provided Min panics", func() {
+			if sContext.UseRedis {
+				// redis supports exclusion
+				return
+			}
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(2)))
+
+			zRange := &redis.ZRangeBy{
+				Min: "(98",
+				Max: "100",
+			}
+			defer assertUnsupportedOperationPanic("Momento currently does not support exclusion of scores")
+			sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+		})
+
+		It("Fetch by score with exclusion rule provided Max panics", func() {
+			if sContext.UseRedis {
+				// redis supports exclusion
+				return
+			}
+			member1 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  98,
+			}
+			member2 := &redis.Z{
+				Member: fmt.Sprintf("member-%s", uuid.NewString()),
+				Score:  100,
+			}
+			setResp := sContext.Client.ZAdd(sContext.Ctx, "sortedSet", *member1, *member2)
+			Expect(setResp.Err()).To(BeNil())
+			Expect(setResp.Val()).To(Equal(int64(2)))
+
+			zRange := &redis.ZRangeBy{
+				Min: "98",
+				Max: "(100",
+			}
+			defer assertUnsupportedOperationPanic("Momento currently does not support exclusion of scores")
+			sContext.Client.ZRangeByScore(sContext.Ctx, "sortedSet", zRange)
+
+		})
+
 		It("Fetch by score no Min", func() {
 			member1 := &redis.Z{
 				Member: fmt.Sprintf("member-%s", uuid.NewString()),

--- a/momento-redis/sorted_set_commands_test.go
+++ b/momento-redis/sorted_set_commands_test.go
@@ -20,7 +20,7 @@ import (
 var _ = Describe("Sorted Set methods", func() {
 	sContext := NewSharedContext()
 	BeforeEach(func() {
-		cacheName := "default_cache"
+		cacheName := fmt.Sprintf("golang-redis-%s", uuid.NewString())
 		switch sContext.UseRedis {
 		case true:
 			host := "127.0.0.1"


### PR DESCRIPTION
Addes sorted set implementations for ZADD and 4 different flavors of FetchByScore for sorted sets