### PR TITLE
chore: let go-redis release as v1.0.0

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -17,7 +17,6 @@ jobs:
         uses: go-semantic-release/action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-initial-development-versions: true
           force-bump-patch-version: true
 
       - name: Output release

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ for more information see the [Current Redis API Support](#current-redis-api-supp
 ## Installation
 
 ```bash
-go get github.com/momentohq/momento-go-redis-client@v0.1.11
+go get github.com/momentohq/momento-go-redis-client
 ```
 
 ## Examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ The examples will utilize your auth token via the environment variable `MOMENTO_
 ## Installation
 
 ```bash
-go get github.com/momentohq/momento-go-redis-client@v0.1.11
+go get github.com/momentohq/momento-go-redis-client
 ```
 
 ### Basic Example

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,3 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-retract (
-	v1.0.0
-)

--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,7 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v1.0.0
+)


### PR DESCRIPTION
Unfortunately go doesn't allow to retract higher versions. We had released a v1.0.0 without knowing it would happen and now go artifacts/indexes are updated with the same that can't be deleted. There's an option to [retract]() versions though we cannot go versions lower. The new version has to be higher than the retracted version https://go.dev/ref/mod#go-mod-file-retract

After discussions with @cprice404 , a new repo might be more confusing with a 0.2.0 and clients might actually just choose this repo as it has v1.0.0 marked. In future, if we have breaking changes, we'll need to bump up the major version to v2.0.0

They do have [support](https://github.com/golang/go/issues/new/?title=x%2Fpkgsite%3A+package+removal+request+for+%5Btype+path+here%5D&body=%0A%3C%21--%0APlease+answer+these+questions+before+submitting+your+issue.+Thanks%21%0A--%3E%0A+%0A%23%23%23+What+is+the+path+of+the+package+that+you+would+like+to+have+removed%3F%0A%0A%3C%21---%0A+We+can+remove+packages+with+a+shared+path+prefix.+For+example%2C+a+request+for+%22github.com%2Fauthor%22+would+remove+all+pkg.go.dev+pages+with+that+package+path+prefix.%0A---%3E+%0A+%0A+%0A%23%23%23+Are+you+the+owner+of+this+package%3F%0A%0A%3C%21---%0AOnly+the+package+owners+can+request+to+have+their+packages+removed+from+pkg.go.dev.%0A---%3E%0A+%0A%23%23%23+What+is+the+reason+that+you+could+not+retract+this+package+instead%3F%0A%0A%3C%21---%0AIf+you+would+like+to+have+your+module+removed+from+pkg.go.dev%2C+we+recommend+that+you+retract+them%2C+so+that+they+can+be+removed+from+the+go+command+and+proxy.golang.org+as+well.%0A%0ARetracting+a+module+version+involves+adding+a+retract+directive+to+your+go.mod+file+and+publishing+a+new+version.+For+example%3A+https%3A%2F%2Fgithub.com%2Fjba%2Fretract-demo%2Fblob%2Fmain%2Fgo.mod%23L5-L8%0A%0ASee+https%3A%2F%2Fgo.dev%2Fabout%23removing-a-package+for+additional+tips+on+retractions.%0A---%3E%0A) for deleting packages but they're still visible through go get/install unless retracted. However, we cannot retract without a higher version number so cutting a request becomes moot.